### PR TITLE
	Fixing the issue so that the version for the artifact.xml is taken

### DIFF
--- a/ide/eclipse/dependencies/wso2-general-project-plugin/.classpath
+++ b/ide/eclipse/dependencies/wso2-general-project-plugin/.classpath
@@ -5,7 +5,7 @@
   <classpathentry kind="output" path="target/classes"/>
   <classpathentry kind="var" path="M2_REPO/javax/mail/mail/1.4/mail-1.4.jar"/>
   <classpathentry kind="var" path="M2_REPO/javax/activation/activation/1.1/activation-1.1.jar"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
   <classpathentry kind="var" path="M2_REPO/biz/aQute/bndlib/0.0.357/bndlib-0.0.357.jar"/>
   <classpathentry kind="var" path="M2_REPO/net/sf/kxml/kxml2/2.2.2/kxml2-2.2.2.jar"/>
   <classpathentry kind="var" path="M2_REPO/xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar"/>
@@ -45,8 +45,8 @@
   <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-monitor/2.0/maven-monitor-2.0.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh/1.0-alpha-5/wagon-ssh-1.0-alpha-5.jar"/>
   <classpathentry kind="var" path="M2_REPO/com/jcraft/jsch/0.1.23/jsch-0.1.23.jar"/>
-  <classpathentry kind="src" path="/org.wso2.maven.utils"/>
-  <classpathentry kind="src" path="/org.wso2.maven.capp"/>
+  <classpathentry kind="var" path="M2_REPO/org/wso2/maven/org.wso2.maven.utils/2.0.0/org.wso2.maven.utils-2.0.0.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/wso2/maven/org.wso2.maven.capp/2.0.6/org.wso2.maven.capp-2.0.6.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/apache/ws/commons/axiom/wso2/axiom/1.2.9-wso2v1/axiom-1.2.9-wso2v1.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/apache/ws/commons/axiom/axiom-impl/1.2.9-wso2v1/axiom-impl-1.2.9-wso2v1.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/apache/ws/commons/axiom/axiom-api/1.2.9-wso2v1/axiom-api-1.2.9-wso2v1.jar"/>
@@ -60,6 +60,6 @@
   <classpathentry kind="var" path="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.9/wstx-asl-3.2.9.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/apache/ws/commons/axiom/axiom-dom/1.2.9-wso2v1/axiom-dom-1.2.9-wso2v1.jar"/>
   <classpathentry kind="var" path="M2_REPO/dom4j/dom4j/1.6.1/dom4j-1.6.1.jar"/>
-  <classpathentry kind="src" path="/org.wso2.maven.core"/>
-  <classpathentry kind="src" path="/org.wso2.maven.registry"/>
+  <classpathentry kind="var" path="M2_REPO/org/wso2/maven/org.wso2.maven.core/2.0.0/org.wso2.maven.core-2.0.0.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/wso2/maven/org.wso2.maven.registry/2.0.1/org.wso2.maven.registry-2.0.1.jar"/>
 </classpath>

--- a/ide/eclipse/dependencies/wso2-general-project-plugin/.project
+++ b/ide/eclipse/dependencies/wso2-general-project-plugin/.project
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-  <name>wso2-general-project-plugin</name>
+  <name>wso2-general-project-plugin-extended</name>
   <comment>NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
-  <projects>
-    <project>org.wso2.maven.utils</project>
-    <project>org.wso2.maven.capp</project>
-    <project>org.wso2.maven.core</project>
-    <project>org.wso2.maven.registry</project>
-  </projects>
+  <projects/>
   <buildSpec>
     <buildCommand>
       <name>org.eclipse.jdt.core.javabuilder</name>

--- a/ide/eclipse/dependencies/wso2-general-project-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/ide/eclipse/dependencies/wso2-general-project-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,5 @@
-#Thu May 19 17:35:59 IST 2011
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
 org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.5

--- a/ide/eclipse/dependencies/wso2-general-project-plugin/pom.xml
+++ b/ide/eclipse/dependencies/wso2-general-project-plugin/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.wso2.maven</groupId>
-  <artifactId>wso2-general-project-plugin</artifactId>
-  <version>2.0.6</version>
+  <artifactId>wso2-general-project-plugin-extended</artifactId>
+  <version>2.0.8</version>
   <packaging>maven-plugin</packaging>
 
   <name>Maven Registry Plugin</name>

--- a/ide/eclipse/dependencies/wso2-general-project-plugin/src/main/java/org/wso2/maven/registry/RegistryResourceMojo.java
+++ b/ide/eclipse/dependencies/wso2-general-project-plugin/src/main/java/org/wso2/maven/registry/RegistryResourceMojo.java
@@ -8,7 +8,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
-import org.wso2.developerstudio.eclipse.utils.archive.ArchiveManipulator;
+import org.wso2.developerstudio.eclipse.utils.archive.ArchiveManipulator; 
 import org.wso2.developerstudio.eclipse.utils.file.FileUtils;
 
 /**
@@ -18,7 +18,8 @@ import org.wso2.developerstudio.eclipse.utils.file.FileUtils;
  * @goal package-registry
  *
  */
-public class RegistryResourceMojo extends AbstractMojo{
+public class RegistryResourceMojo extends AbstractMojo{	
+	
 	/**
 	 * @parameter default-value="${project}"
 	 */


### PR DESCRIPTION
WIth the current version of wso2-general-project-plugin, the version of the generated artifact.xml is always hardcoded to be the ${project.version}. This prevents a user to have a different version of the artifact for the same project.
One more problem with this approach is when using M2 release plugin to release a project. In the release:prepare phase the project.version is still a SNAPSHOT version and this version gets propagated to the artifact.xml, which is wrong.
To avoid the above problems and to give the user more flexibility in terms of versioning the artifact, the new approach proposed and implemented in the code is to honor the version defined in the version attribute of the artifact.xml. If the version defined is a maven property, it should be resolved and used. If the version defined is invalid or not defined then it should fallback to the $project.version, thus maintaining backward compatibility.
So, with the new approach if someone now wants to release the esb registry resources project using M2 release plugin. He/she has to just use a property named ${releaseVersion} in the version attribute of the artifact.xml. Since, M2 release plugin always injects a -DreleaseVersion=<VERSION DEFINED BY THE USER> as part of maven build. This will make the release process seamless and easy. 
If someone wants to run just  a maven clean or an install goal, he/she has to just define a maven property named releaseVersion in the pom.xml with the default value being $project.version.
